### PR TITLE
Fix for urls with non-ascii characters being double encoded.

### DIFF
--- a/bitly_api/bitly_api.py
+++ b/bitly_api/bitly_api.py
@@ -58,7 +58,7 @@ class Connection(object):
         params = {
             'login': self.login,
             'apiKey': self.api_key,
-            'uri':uri.encode('UTF-8')
+            'uri':uri
         }
         if preferred_domain:
             params['domain'] = preferred_domain


### PR DESCRIPTION
Urls to be shorted were being double-encoded. This would fail if a url actually contained any non-ascii characters. Connection.shorten was encoding the url via url.encode('UTF-8'). This, however, was already being done in the _call method. I removed the encoding in shorten.
