### PR TITLE
Username/AccessToken provided via Environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,16 @@ bitly API python library
 
     pip install bitly_api
 
+## Run tests
+
+Your username is the lowercase name shown when you login to bitly, your access token can be fetched using the following ( http://dev.bitly.com/authentication.html ):
+
+    curl -u "username:password" -X POST "https://api-ssl.bitly.com/oauth/access_token"
+
+To run the tests either export the environment variable or set it up inline before calling `nosetests`:
+
+    bitly-api-python $ BITLY_ACCESS_TOKEN=<accesstoken> nosetests
+
 ## API Documentation
 
 http://dev.bitly.com/

--- a/test/test_bitly_api.py
+++ b/test/test_bitly_api.py
@@ -1,33 +1,53 @@
 #!/usr/local/bin/python
 """
 This is a py.test script
+
+Example usage on Unix:
+bitly-api-python $ BITLY_ACCESS_TOKEN=<accesstoken> nosetests
+or 'export' the two environment variables prior to running nosetests
 """
+import os
 import sys
 sys.path.append('../')
 import bitly_api
 
+BITLY_ACCESS_TOKEN = "BITLY_ACCESS_TOKEN"
+
+
+def get_connection():
+    """Create a Connection base on username and access token credentials"""
+    if BITLY_ACCESS_TOKEN not in os.environ:
+        raise ValueError("Environment variable '{}' required".format(BITLY_ACCESS_TOKEN))
+    access_token = os.getenv(BITLY_ACCESS_TOKEN)
+    bitly = bitly_api.Connection(access_token=access_token)
+    return bitly
+
+
 def testApi():
-    bitly = bitly_api.Connection('bitlyapidemo','R_0da49e0a9118ff35f52f629d2d71bf07')
+    bitly = get_connection()
     data = bitly.shorten('http://google.com/')
-    assert data != None
+    assert data is not None
     assert data['long_url'] == 'http://google.com/'
-    assert data['hash'] != None
-    
+    assert data['hash'] is not None
+
+
 def testExpand():
-    bitly = bitly_api.Connection('bitlyapidemo','R_0da49e0a9118ff35f52f629d2d71bf07')
-    data = bitly.expand(hash='test1')
-    assert data != None
+    bitly = get_connection()
+    data = bitly.expand(hash='test1_random_fjslfjieljfklsjflkas')
+    assert data is not None
     assert len(data) == 1
     assert data[0]['error'] == 'NOT_FOUND'
-    
+
+
 def testReferrer():
-    bitly = bitly_api.Connection('bitlyapidemo','R_0da49e0a9118ff35f52f629d2d71bf07')
+    bitly = get_connection()
     data = bitly.referrers(hash='a')
-    assert data != None
+    assert data is not None
     assert len(data) > 1
 
+
 def testProDomain():
-    bitly = bitly_api.Connection('bitlyapidemo','R_0da49e0a9118ff35f52f629d2d71bf07')
+    bitly = get_connection()
     test_data = {
         'cnn.com': False,
         'nyti.ms': True,


### PR DESCRIPTION
Username and AccessToken are imported using environment variables. If they're missing then a useful error is raised. README updated to explain how to set this up, doc added in test_bitly_api.py to explain how to run the test.

One test changed in test_bitly_api as the 'test1' key is a valid bitly key, maybe this entered the keyspace? I've added a longer random string, I don't know if this keeps the same meaning to the test (this needs validation).
